### PR TITLE
ErrorStatus 가독성을 위한 리팩토링

### DIFF
--- a/src/main/java/com/example/fittoserver/domain/auth/jwt/CustomLogoutFilter.java
+++ b/src/main/java/com/example/fittoserver/domain/auth/jwt/CustomLogoutFilter.java
@@ -44,7 +44,7 @@ public class CustomLogoutFilter extends GenericFilterBean {
 
         String refresh = refreshTokenService.extractRefreshToken(request);
         if (refresh == null) {
-            throw new GeneralException(ErrorStatus.INVALID_REFRESH_TOKEN); // Refresh Token이 없는 경우 예외 처리
+            throw new GeneralException(ErrorStatus.REFRESH_TOKEN_NOT_FOUND); // Refresh Token이 없는 경우 예외 처리
         }
         // 유효성 검사 및 예외 발생
         refreshTokenService.validateRefreshToken(refresh);

--- a/src/main/java/com/example/fittoserver/domain/auth/jwt/JWTFilter.java
+++ b/src/main/java/com/example/fittoserver/domain/auth/jwt/JWTFilter.java
@@ -49,7 +49,7 @@ public class JWTFilter extends OncePerRequestFilter {
 
         String category = jwtUtil.getCategory(token);
         if (!"access".equals(category)) {
-            throw new GeneralException(ErrorStatus.INVALID_ACCESS_TOKEN);
+            throw new GeneralException(ErrorStatus.TOKEN_CATEGORY_MISMATCH);
         }
 
         String hashedUserId = jwtUtil.getUserId(token);
@@ -59,7 +59,7 @@ public class JWTFilter extends OncePerRequestFilter {
         }
 
         UserEntity user = userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         Authentication authToken =
                 new UsernamePasswordAuthenticationToken(user, null, Collections.singleton(() -> user.getRole()));

--- a/src/main/java/com/example/fittoserver/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/example/fittoserver/domain/auth/service/RefreshTokenService.java
@@ -31,7 +31,7 @@ public class RefreshTokenService {
                 }
             }
         }else{
-            throw new GeneralException(ErrorStatus.REFRESH_TOKEN_IS_NULL); // Refresh 토큰이 없으면 예외 처리
+            throw new GeneralException(ErrorStatus.REFRESH_TOKEN_NOT_FOUND); // Refresh 토큰이 없으면 예외 처리
         }
         return refresh;
     }
@@ -42,7 +42,7 @@ public class RefreshTokenService {
             jwtUtil.isExpired(refresh); // Expired check
             String category = jwtUtil.getCategory(refresh);
             if (!category.equals("refresh")) {
-                throw new GeneralException(ErrorStatus.INVALID_REFRESH_TOKEN); // Refresh 토큰이 아닌 경우
+                throw new GeneralException(ErrorStatus.TOKEN_CATEGORY_MISMATCH); // Refresh 토큰이 아닌 경우
             }
 
             String hashedUserId = jwtUtil.getUserId(refresh);
@@ -50,7 +50,7 @@ public class RefreshTokenService {
             // Redis에서 존재 여부 확인
             String storedRefreshToken = refreshUtil.getRefreshToken(hashedUserId);
             if (storedRefreshToken == null || !storedRefreshToken.equals(refresh)) {
-                throw new GeneralException(ErrorStatus.REFRESH_TOKEN_NOT_EXIST); // Redis에서 없거나 일치하지 않으면
+                throw new GeneralException(ErrorStatus.INVALID_REFRESH_TOKEN); // Redis에서 없거나 일치하지 않으면
             }
         } catch (ExpiredJwtException e) {
             throw new GeneralException(ErrorStatus.REFRESH_TOKEN_EXPIRED); // Expired Token 예외 처리

--- a/src/main/java/com/example/fittoserver/domain/auth/service/ReissueService.java
+++ b/src/main/java/com/example/fittoserver/domain/auth/service/ReissueService.java
@@ -25,7 +25,7 @@ public class ReissueService {
 
         String refresh = refreshTokenService.extractRefreshToken(request);
         if (refresh == null) {
-            throw new GeneralException(ErrorStatus.INVALID_REFRESH_TOKEN); // Refresh Token이 없는 경우 예외 처리
+            throw new GeneralException(ErrorStatus.REFRESH_TOKEN_NOT_FOUND); // Refresh Token이 없는 경우 예외 처리
         }
 
         // 유효성 검사 및 예외 발생

--- a/src/main/java/com/example/fittoserver/global/common/api/status/ErrorStatus.java
+++ b/src/main/java/com/example/fittoserver/global/common/api/status/ErrorStatus.java
@@ -10,36 +10,89 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorStatus implements BaseCode {
 
-    // 가장 일반적인 응답
-    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
-    _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
-    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
-    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
-    _PARSING_ERROR(HttpStatus.FORBIDDEN, "COMMON500", "JSON 파싱 에러."),
+// ========================
+// 400 Bad Request
+// ========================
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "400_000", "잘못된 요청입니다."),
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "400_001", "입력값이 올바르지 않습니다."),
+    INVALID_FILE_FORMAT(HttpStatus.BAD_REQUEST, "400_002", "업로드된 파일 형식이 올바르지 않습니다."),
+    NULL_VALUE(HttpStatus.BAD_REQUEST, "400_003", "Null 값이 들어왔습니다."),
+    TEST_ERROR(HttpStatus.BAD_REQUEST, "400_004", "테스트 에러입니다."),
+    PAGE_NOT_EXIST(HttpStatus.BAD_REQUEST, "PAGE001", "페이지가 0 이하입니다."),
 
 
-    // 멤버 관려 에러
-    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
-    MEMBER_IS_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "사용자가 이미 존재합니다.."),
-    NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4003", "닉네임은 필수 입니다."),
+// ========================
+// 401 Unauthorized
+// ========================
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "401_000", "토큰이 만료되었습니다."),
+    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "401_001", "유효하지 않은 토큰입니다."),
+    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "401_002", "토큰이 존재하지 않습니다."),
+    TOKEN_CATEGORY_MISMATCH(HttpStatus.UNAUTHORIZED, "401_003", "토큰 형식이 일치하지 않습니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "401_004", "인증 정보가 올바르지 않습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "401_005", "토큰이 생성되지 않았습니다."),
+    INVALID_LOGIN(HttpStatus.UNAUTHORIZED, "401_006", "로그인이 필요합니다."),
 
-    // 토큰 관련 에러
-    ACCESS_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "TOKEN4001", "액세스 토큰이 만료되었습니다."),
-    REFRESH_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "TOKEN4002", "리프레시 토큰이 만료되었습니다."),
-    INVALID_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "TOKEN4003", "토큰이 올바르지 않습니다."),
-    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "TOKEN4004", "토큰이 올바르지 않습니다."),
-    REFRESH_TOKEN_NOT_EXIST(HttpStatus.BAD_REQUEST, "TOKEN4005", "리프레시 토큰이 존재하지 않습니다."),
-    REFRESH_TOKEN_IS_NULL(HttpStatus.BAD_REQUEST, "TOKEN4006", "리프레시 토큰이 null입니다."),
+    // 액세스 토큰
+    ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "401_010", "액세스 토큰이 만료되었습니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "401_011", "액세스 토큰이 유효하지 않습니다."),
+    ACCESS_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "401_012", "액세스 토큰이 존재하지 않습니다."),
+
+    // 리프레시 토큰
+    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "401_020", "리프레시 토큰이 만료되었습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "401_021", "리프레시 토큰이 유효하지 않습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "401_022", "저장된 리프레시 토큰이 존재하지 않습니다."),
+    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "401_023", "저장된 리프레시 토큰과 일치하지 않습니다."),
 
 
-    // 예시,,,
-    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다."),
+// ========================
+// 403 Forbidden
+// ========================
+    FORBIDDEN(HttpStatus.FORBIDDEN, "403_000", "접속 권한이 없습니다."),
+    ACCESS_DENY(HttpStatus.FORBIDDEN, "403_001", "접근이 거부되었습니다."),
 
-    // For test
-    TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "이거는 테스트"),
 
-    // 페이징 에러
-    PAGE_NOT_EXIST(HttpStatus.BAD_REQUEST, "PAGE001", "페이지가 0 이하입니다.");
+// ========================
+// 404 Not Found
+// ========================
+
+    NOT_FOUND_END_POINT(HttpStatus.NOT_FOUND, "404_000", "요청한 대상이 존재하지 않습니다."),
+
+    // USER
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "404_010", "해당 사용자를 찾을 수 없습니다."),
+
+    // MEETING
+    MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "404_020", "해당 미팅을 찾을 수 없습니다."),
+
+    // MEMBER
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "404_030", "해당 멤버를 찾을 수 없습니다."),
+
+    // CHALLENGE
+    CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "404_040", "해당 챌린지를 찾을 수 없습니다."),
+
+    // WORKOUT
+    WORKOUT_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "404_050", "해당 운동기록을 찾을 수 없습니다."),
+
+
+
+// ========================
+// 409 Conflict
+// ========================
+
+    // USER
+    USER_IS_EXIST(HttpStatus.CONFLICT, "409_010", "사용자가 이미 존재합니다."),
+
+
+// ========================
+// 500 Internal Server Error
+// ========================
+
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500_000", "서버 내부 오류입니다."),
+    _PARSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500_001", "JSON 파싱 에러."),
+
+    // 외부 API
+    _KAKAO_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500_010", "KAKAO API 오류입니다."),
+
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## 연관 이슈
- Closes #6 

---

## 작업 내용
- ErrorStatus 구조 및 코드 변경: 기존에는 에러 코드에는 HTTP 상태 코드를 넣지 않았는데 에러 코드를 {HTTP상태코드}_{커스텀 코드} 이렇게 변경 -> 에러 코드만 보고도 에러 이유를 유추할 수 있고 커스텀 코드에서 도메인을 적용하여 좀 더 많은 의미를 담음.

---
