### PR TITLE
Spring Security 인증 실패 핸들러 및 커스텀 응답 설정

### DIFF
--- a/src/main/java/com/example/fittoserver/domain/auth/service/KakaoAuthService.java
+++ b/src/main/java/com/example/fittoserver/domain/auth/service/KakaoAuthService.java
@@ -3,7 +3,7 @@ package com.example.fittoserver.domain.auth.service;
 import com.example.fittoserver.domain.auth.converter.AuthConverter;
 import com.example.fittoserver.domain.auth.dto.AuthResponseDTO;
 import com.example.fittoserver.domain.auth.dto.KakaoDTO;
-import com.example.fittoserver.domain.auth.jwt.JWTUtil;
+import com.example.fittoserver.global.security.jwt.JWTUtil;
 import com.example.fittoserver.domain.auth.util.KakaoUtil;
 import com.example.fittoserver.domain.user.entity.UserEntity;
 import com.example.fittoserver.domain.user.converter.UserConverter;

--- a/src/main/java/com/example/fittoserver/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/example/fittoserver/domain/auth/service/RefreshTokenService.java
@@ -3,7 +3,7 @@ package com.example.fittoserver.domain.auth.service;
 import com.example.fittoserver.global.common.api.status.ErrorStatus;
 import com.example.fittoserver.global.exception.GeneralException;
 import com.example.fittoserver.global.common.util.RefreshUtil;
-import com.example.fittoserver.domain.auth.jwt.JWTUtil;
+import com.example.fittoserver.global.security.jwt.JWTUtil;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/example/fittoserver/domain/auth/service/ReissueService.java
+++ b/src/main/java/com/example/fittoserver/domain/auth/service/ReissueService.java
@@ -2,7 +2,7 @@ package com.example.fittoserver.domain.auth.service;
 
 import com.example.fittoserver.global.common.api.status.ErrorStatus;
 import com.example.fittoserver.global.exception.GeneralException;
-import com.example.fittoserver.domain.auth.jwt.JWTUtil;
+import com.example.fittoserver.global.security.jwt.JWTUtil;
 import com.example.fittoserver.global.common.util.CookieUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/com/example/fittoserver/domain/auth/util/KakaoUtil.java
+++ b/src/main/java/com/example/fittoserver/domain/auth/util/KakaoUtil.java
@@ -1,11 +1,11 @@
 package com.example.fittoserver.domain.auth.util;
 
-import com.example.fittoserver.domain.auth.dto.AuthResponseDTO;
 import com.example.fittoserver.domain.auth.dto.KakaoDTO;
 import com.example.fittoserver.global.common.api.status.ErrorStatus;
 import com.example.fittoserver.global.exception.GeneralException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
@@ -18,6 +18,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 @Component
+@RequiredArgsConstructor
 @Slf4j
 public class KakaoUtil {
 
@@ -29,6 +30,8 @@ public class KakaoUtil {
     private String tokenUri;
     @Value("${spring.kakao.user-info-uri}")
     private String userInfoUri;
+
+    private final ObjectMapper objectMapper;
 
     public KakaoDTO.OAuthToken requestToken(String accessCode) {
         RestTemplate restTemplate = new RestTemplate();
@@ -48,8 +51,6 @@ public class KakaoUtil {
                 HttpMethod.POST,
                 kakaoTokenRequest,
                 String.class);
-
-        ObjectMapper objectMapper = new ObjectMapper();
 
         KakaoDTO.OAuthToken oAuthToken = null;
 
@@ -76,8 +77,6 @@ public class KakaoUtil {
                 HttpMethod.GET,
                 kakaoProfileRequest,
                 String.class);
-
-        ObjectMapper objectMapper = new ObjectMapper();
 
         KakaoDTO.KakaoProfile kakaoProfile = null;
 

--- a/src/main/java/com/example/fittoserver/global/common/api/status/ErrorStatus.java
+++ b/src/main/java/com/example/fittoserver/global/common/api/status/ErrorStatus.java
@@ -24,9 +24,9 @@ public enum ErrorStatus implements BaseCode {
 // ========================
 // 401 Unauthorized
 // ========================
-    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "401_000", "토큰이 만료되었습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "401_000", "인증되지 않은 사용자입니다."),
     TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "401_001", "유효하지 않은 토큰입니다."),
-    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "401_002", "토큰이 존재하지 않습니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "401_002", "토큰이 만료되었습니다."),
     TOKEN_CATEGORY_MISMATCH(HttpStatus.UNAUTHORIZED, "401_003", "토큰 형식이 일치하지 않습니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "401_004", "인증 정보가 올바르지 않습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "401_005", "토큰이 생성되지 않았습니다."),

--- a/src/main/java/com/example/fittoserver/global/security/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/example/fittoserver/global/security/handler/JwtAccessDeniedHandler.java
@@ -1,0 +1,39 @@
+package com.example.fittoserver.global.security.handler;
+
+import com.example.fittoserver.global.common.api.ApiResponse;
+import com.example.fittoserver.global.common.api.status.ErrorStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        ErrorStatus errorStatus = ErrorStatus.FORBIDDEN;
+
+        response.setStatus(errorStatus.getHttpStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        ApiResponse<?> errorResponse = ApiResponse.onFailure(
+                errorStatus.getCode(),
+                errorStatus.getMessage(),
+                null
+        );
+
+        String json = objectMapper.writeValueAsString(errorResponse);
+        response.getWriter().write(json);
+    }
+}

--- a/src/main/java/com/example/fittoserver/global/security/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/fittoserver/global/security/handler/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,40 @@
+package com.example.fittoserver.global.security.handler;
+
+import com.example.fittoserver.global.common.api.ApiResponse;
+import com.example.fittoserver.global.common.api.status.ErrorStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.web.ErrorResponse;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        ErrorStatus errorStatus = ErrorStatus.UNAUTHORIZED;
+
+        response.setStatus(errorStatus.getHttpStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        ApiResponse<?> errorResponse = ApiResponse.onFailure(
+                errorStatus.getCode(),
+                errorStatus.getMessage(),
+                null
+        );
+
+        String json = objectMapper.writeValueAsString(errorResponse);
+        response.getWriter().write(json);
+    }
+}

--- a/src/main/java/com/example/fittoserver/global/security/jwt/CustomLogoutFilter.java
+++ b/src/main/java/com/example/fittoserver/global/security/jwt/CustomLogoutFilter.java
@@ -1,4 +1,4 @@
-package com.example.fittoserver.domain.auth.jwt;
+package com.example.fittoserver.global.security.jwt;
 
 import com.example.fittoserver.global.common.api.status.ErrorStatus;
 import com.example.fittoserver.global.exception.GeneralException;

--- a/src/main/java/com/example/fittoserver/global/security/jwt/JWTFilter.java
+++ b/src/main/java/com/example/fittoserver/global/security/jwt/JWTFilter.java
@@ -1,4 +1,4 @@
-package com.example.fittoserver.domain.auth.jwt;
+package com.example.fittoserver.global.security.jwt;
 
 import com.example.fittoserver.domain.user.repository.UserRepository;
 import com.example.fittoserver.global.common.api.status.ErrorStatus;

--- a/src/main/java/com/example/fittoserver/global/security/jwt/JWTUtil.java
+++ b/src/main/java/com/example/fittoserver/global/security/jwt/JWTUtil.java
@@ -1,4 +1,4 @@
-package com.example.fittoserver.domain.auth.jwt;
+package com.example.fittoserver.global.security.jwt;
 
 import io.jsonwebtoken.Jwts;
 import org.springframework.beans.factory.annotation.Value;


### PR DESCRIPTION
## 연관 이슈
- #8 

---

## 작업 내용
- ObjectMapper 직접 생성 -> 빈 주입으로 변경
- exceptionHandling 추가
  - JwtAuthenticationEntryPoint(401) 핸들러
  - JwtAccessDeniedHandler(403) 핸들러

---

## 트러블슈팅 / 고민한 점
- 테스트 코드 도입을 고려했을 때, ObjectMapper를 직접 생성하는 방식은 스프링의 설정과 충돌해 예기치 않은 결과를 초래할 수 있다고 판단. 커스터마이징은 없지만, 테스트와 유지보수 측면에서 더 안정적인 구조를 위해 빈으로 주입받도록 변경.

---

## 결과
<img width="374" height="208" alt="스크린샷 2025-08-03 175230" src="https://github.com/user-attachments/assets/4af6e871-da94-4448-ad63-8fad6b11630d" />

---

## 참고 자료
- [[Spring Security] 401, 403 에러처리(Spring 3.xx)](https://develoyummer.tistory.com/158)
