### PR TITLE
관리자 전용 로그인 API 구현

### DIFF
--- a/src/main/java/com/example/fittoserver/application/auth/AuthController.java
+++ b/src/main/java/com/example/fittoserver/application/auth/AuthController.java
@@ -2,6 +2,7 @@ package com.example.fittoserver.application.auth;
 
 import com.example.fittoserver.domain.auth.dto.AuthRequestDTO;
 import com.example.fittoserver.domain.auth.dto.AuthResponseDTO;
+import com.example.fittoserver.domain.auth.service.AdminService;
 import com.example.fittoserver.domain.auth.service.KakaoAuthService;
 import com.example.fittoserver.domain.auth.service.ReissueService;
 import com.example.fittoserver.global.common.api.ApiResponse;
@@ -26,6 +27,7 @@ public class AuthController {
 
     private final ReissueService reissueService;
     private final KakaoAuthService kakaoAuthService;
+    private final AdminService adminService;
 
     @Operation(summary = "카카오 로그인 및 회원가입")
     @PostMapping("/login/kakao")
@@ -40,6 +42,14 @@ public class AuthController {
         Cookie refreshCookie = CookieUtil.createCookie("refresh", loginResult.getRefreshToken());
         response.addCookie(refreshCookie);
         return ApiResponse.onSuccess(loginResult.getLoginRes());
+    }
+
+    @Operation(summary = "관리자 로그인")
+    @PostMapping("/login/admin")
+    public ApiResponse<AuthResponseDTO.LoginWithAdminRes> loginWithAdmin(
+            @Valid @RequestBody AuthRequestDTO.LoginWithAdminReq request,
+            HttpServletResponse response) {
+        return ApiResponse.onSuccess(adminService.loginWithAdmin(request));
     }
 
     @Operation(summary = "토큰 재발행")

--- a/src/main/java/com/example/fittoserver/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/com/example/fittoserver/domain/auth/converter/AuthConverter.java
@@ -18,4 +18,11 @@ public class AuthConverter {
                 .userId(hashedUserId)
                 .build();
     }
+
+    public static AuthResponseDTO.LoginWithAdminRes toLoginWithAdminRes(String accessToken, String refreshToken){
+        return AuthResponseDTO.LoginWithAdminRes.builder()
+                .access(accessToken)
+                .refresh(refreshToken)
+                .build();
+    }
 }

--- a/src/main/java/com/example/fittoserver/domain/auth/dto/AuthRequestDTO.java
+++ b/src/main/java/com/example/fittoserver/domain/auth/dto/AuthRequestDTO.java
@@ -12,4 +12,11 @@ public class AuthRequestDTO {
         @NotEmpty
         private String accessCode;
     }
+
+    @Getter
+    public static class LoginWithAdminReq{
+
+        @NotEmpty
+        private String adminKey;
+    }
 }

--- a/src/main/java/com/example/fittoserver/domain/auth/dto/AuthResponseDTO.java
+++ b/src/main/java/com/example/fittoserver/domain/auth/dto/AuthResponseDTO.java
@@ -15,10 +15,15 @@ public class AuthResponseDTO {
 
     @Builder
     @Getter
-    public static class LoginRes {
-        private String userId;
+    public static class LoginWithAdminRes {
         private String access;
         private String refresh;
+    }
+
+    @Builder
+    @Getter
+    public static class LoginRes {
+        private String userId;
     }
 
     @Getter

--- a/src/main/java/com/example/fittoserver/domain/auth/service/AdminService.java
+++ b/src/main/java/com/example/fittoserver/domain/auth/service/AdminService.java
@@ -1,0 +1,44 @@
+package com.example.fittoserver.domain.auth.service;
+
+import com.example.fittoserver.domain.auth.converter.AuthConverter;
+import com.example.fittoserver.domain.auth.dto.AuthRequestDTO;
+import com.example.fittoserver.domain.auth.dto.AuthResponseDTO;
+import com.example.fittoserver.domain.user.entity.UserEntity;
+import com.example.fittoserver.domain.user.service.UserService;
+import com.example.fittoserver.global.common.api.status.ErrorStatus;
+import com.example.fittoserver.global.common.util.HashIdUtil;
+import com.example.fittoserver.global.exception.GeneralException;
+import com.example.fittoserver.global.security.jwt.JWTUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+    @Value("${admin.login-key}")
+    private String adminKey;
+
+    private final JWTUtil jwtUtil;
+    private final UserService userService;
+    private final HashIdUtil hashIdUtil;
+
+    public AuthResponseDTO.LoginWithAdminRes loginWithAdmin(AuthRequestDTO.LoginWithAdminReq request) {
+
+        // 키 검증
+        if (!adminKey.equals(request.getAdminKey())) {
+            throw new GeneralException(ErrorStatus.ACCESS_DENY);
+        }
+
+        UserEntity admin = userService.getAdmin()
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        String hashedUserId = hashIdUtil.encode(admin.getId());
+
+        String access = jwtUtil.createJwt("access", hashedUserId, admin.getRole(), 600_000L);      // 10분
+        String refresh = jwtUtil.createJwt("refresh", hashedUserId, admin.getRole(), 86_400_000L); // 24시간
+
+        return AuthConverter.toLoginWithAdminRes(access, refresh);
+    }
+}

--- a/src/main/java/com/example/fittoserver/domain/user/entity/UserEntity.java
+++ b/src/main/java/com/example/fittoserver/domain/user/entity/UserEntity.java
@@ -16,7 +16,7 @@ public class UserEntity extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = true, unique = true)
     private Long kakaoId;
 
     @Column(nullable = false)

--- a/src/main/java/com/example/fittoserver/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/fittoserver/domain/user/repository/UserRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
     Optional<UserEntity> findByKakaoId(Long kakaoId);
+    Optional<UserEntity> findByRole(String role);
 }

--- a/src/main/java/com/example/fittoserver/domain/user/service/UserService.java
+++ b/src/main/java/com/example/fittoserver/domain/user/service/UserService.java
@@ -2,18 +2,22 @@ package com.example.fittoserver.domain.user.service;
 
 import com.example.fittoserver.domain.user.entity.UserEntity;
 import com.example.fittoserver.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
+@RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
 
-    public UserService(UserRepository userRepository) {
-        this.userRepository = userRepository;
-    }
-
     public UserEntity saveUser(UserEntity user) {
         return userRepository.save(user);
+    }
+
+    public Optional<UserEntity> getAdmin() {
+        return userRepository.findByRole("ROLE_ADMIN");
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,9 @@ spring:
 hashid:
   salt: fitto
 
+admin:
+  login-key: SUPER_SECRET_DEV_ADMIN_KEY
+
 springdoc:
   show-login-endpoint: true
 


### PR DESCRIPTION
## 연관 이슈
- #11 

---

## 작업 내용
- 관리자 로그인 구현
- adminKey를 환경변수로 저장하고 이를 통해 로그인
- UserEntity의 kakaoId칼럼을 null 허용으로 변경 : ADMIN은 kakaoId가 없기 때문

---

## 트러블슈팅 / 고민한 점
- admin 도메인을 분리해야 하나?
  - 도메인 중복/혼란
    - 예를 들어 admin 도메인을 만들면 /admin/meeting , /meeting 이렇게 될텐데 이러면 도메인 레이어가 중복되고 동작은 같고 복잡해질 것
  - 따라서 도메인은 그대로 두고 ADMIN 권한 제한 어노테이션을 추가해 URL은 유지  
- ADMIN 계정을 환경변수로 관리 vs 유저로 추가
  - 현재 토큰을 통해 인증을 하고 있는 방식이라 ADMIN을 인증하면 이때도 토큰이 발급되어야함 (role은 ADMIN)
  - 토큰에서 현재 userId를 해싱해서 사용하고 있으므로 ADMIN을 유저로 추가하는 것이 기존의 방식을 이어가고 권한만 다르고 일반 유저와 로직 공유 가능
  - 따라서 유저로 추가하는 것이 유지보수 측면에서도 유리 

---

## 결과
<img width="1310" height="487" alt="스크린샷 2025-08-08 001910" src="https://github.com/user-attachments/assets/ee6f7e05-c835-4148-b10c-d327d57e3db7" />
